### PR TITLE
Distance_between_2_nodes(GPS Locations)

### DIFF
--- a/functions/Distance_between_2_nodes.ipynb
+++ b/functions/Distance_between_2_nodes.ipynb
@@ -1,0 +1,210 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "pip install osmnx"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dKvoT7_NwbMD",
+        "outputId": "97c1d580-f3af-443d-e102-cbd37ebb5bf0"
+      },
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting osmnx\n",
+            "  Downloading osmnx-2.0.0-py3-none-any.whl.metadata (4.8 kB)\n",
+            "Requirement already satisfied: geopandas>=1.0 in /usr/local/lib/python3.10/dist-packages (from osmnx) (1.0.1)\n",
+            "Requirement already satisfied: networkx>=2.5 in /usr/local/lib/python3.10/dist-packages (from osmnx) (3.4.2)\n",
+            "Requirement already satisfied: numpy>=1.22 in /usr/local/lib/python3.10/dist-packages (from osmnx) (1.26.4)\n",
+            "Requirement already satisfied: pandas>=1.4 in /usr/local/lib/python3.10/dist-packages (from osmnx) (2.2.2)\n",
+            "Requirement already satisfied: requests>=2.27 in /usr/local/lib/python3.10/dist-packages (from osmnx) (2.32.3)\n",
+            "Requirement already satisfied: shapely>=2.0 in /usr/local/lib/python3.10/dist-packages (from osmnx) (2.0.6)\n",
+            "Requirement already satisfied: pyogrio>=0.7.2 in /usr/local/lib/python3.10/dist-packages (from geopandas>=1.0->osmnx) (0.10.0)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from geopandas>=1.0->osmnx) (24.2)\n",
+            "Requirement already satisfied: pyproj>=3.3.0 in /usr/local/lib/python3.10/dist-packages (from geopandas>=1.0->osmnx) (3.7.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas>=1.4->osmnx) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas>=1.4->osmnx) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas>=1.4->osmnx) (2024.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.27->osmnx) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.27->osmnx) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.27->osmnx) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.27->osmnx) (2024.8.30)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas>=1.4->osmnx) (1.16.0)\n",
+            "Downloading osmnx-2.0.0-py3-none-any.whl (99 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m99.4/99.4 kB\u001b[0m \u001b[31m2.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: osmnx\n",
+            "Successfully installed osmnx-2.0.0\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "pip install networkx"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "rC2a1OW0wesl",
+        "outputId": "c26e59d3-638f-4966-b2ee-14a284c86dc4"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (3.4.2)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "pip install geopandas shapely matplotlib"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "RX4oerHVwgYY",
+        "outputId": "e7e23709-559d-40a7-b3e9-64058c8ad482"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: geopandas in /usr/local/lib/python3.10/dist-packages (1.0.1)\n",
+            "Requirement already satisfied: shapely in /usr/local/lib/python3.10/dist-packages (2.0.6)\n",
+            "Requirement already satisfied: matplotlib in /usr/local/lib/python3.10/dist-packages (3.8.0)\n",
+            "Requirement already satisfied: numpy>=1.22 in /usr/local/lib/python3.10/dist-packages (from geopandas) (1.26.4)\n",
+            "Requirement already satisfied: pyogrio>=0.7.2 in /usr/local/lib/python3.10/dist-packages (from geopandas) (0.10.0)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from geopandas) (24.2)\n",
+            "Requirement already satisfied: pandas>=1.4.0 in /usr/local/lib/python3.10/dist-packages (from geopandas) (2.2.2)\n",
+            "Requirement already satisfied: pyproj>=3.3.0 in /usr/local/lib/python3.10/dist-packages (from geopandas) (3.7.0)\n",
+            "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib) (1.3.1)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.10/dist-packages (from matplotlib) (0.12.1)\n",
+            "Requirement already satisfied: fonttools>=4.22.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib) (4.55.0)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib) (1.4.7)\n",
+            "Requirement already satisfied: pillow>=6.2.0 in /usr/local/lib/python3.10/dist-packages (from matplotlib) (11.0.0)\n",
+            "Requirement already satisfied: pyparsing>=2.3.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib) (3.2.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.10/dist-packages (from matplotlib) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas>=1.4.0->geopandas) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas>=1.4.0->geopandas) (2024.2)\n",
+            "Requirement already satisfied: certifi in /usr/local/lib/python3.10/dist-packages (from pyogrio>=0.7.2->geopandas) (2024.8.30)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.7->matplotlib) (1.16.0)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LcN3My7iunWk",
+        "outputId": "143ebd0a-8209-41d5-c777-794b8574717c"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Geodesic distance: 8212.45 meters\n",
+            "Road network distance: 7492.77 meters\n"
+          ]
+        }
+      ],
+      "source": [
+        "from geopy.distance import geodesic\n",
+        "import osmnx as ox\n",
+        "import networkx as nx\n",
+        "\n",
+        "def calculate_distance(coord1, coord2, use_road_network=True):\n",
+        "    \"\"\"\n",
+        "    Calculate the distance between two GPS coordinates.\n",
+        "\n",
+        "    Args:\n",
+        "        coord1 (tuple): The first coordinate as (latitude, longitude).\n",
+        "        coord2 (tuple): The second coordinate as (latitude, longitude).\n",
+        "        use_road_network (bool): If True, calculates distance using road network.\n",
+        "                                 If False, calculates straight-line geodesic distance.\n",
+        "\n",
+        "    Returns:\n",
+        "        float: Distance in meters.\n",
+        "    \"\"\"\n",
+        "    if not use_road_network:\n",
+        "        # Calculate geodesic distance\n",
+        "        distance_meters = geodesic(coord1, coord2).meters\n",
+        "        return distance_meters\n",
+        "    else:\n",
+        "        # Download road network for the area\n",
+        "        G = ox.graph_from_point(coord1, dist=5000, network_type='drive')\n",
+        "\n",
+        "        # Find the nearest nodes in the road network\n",
+        "        node1 = ox.distance.nearest_nodes(G, coord1[1], coord1[0])\n",
+        "        node2 = ox.distance.nearest_nodes(G, coord2[1], coord2[0])\n",
+        "\n",
+        "        # Calculate the shortest path distance using the road network\n",
+        "        try:\n",
+        "            distance_meters = nx.shortest_path_length(G, node1, node2, weight='length')\n",
+        "        except nx.NetworkXNoPath:\n",
+        "            distance_meters = None  # No path exists between the two points\n",
+        "\n",
+        "        return distance_meters\n",
+        "\n",
+        "# Example Usage\n",
+        "coord1 = (54.78769, 9.4651324)  # Bridge location.\n",
+        "coord2 = (54.78795, 9.3374747)   # Seimens provided location near/faraway the bridge.\n",
+        "\n",
+        "# Geodesic distance (straight-line)\n",
+        "geo_distance = calculate_distance(coord1, coord2, use_road_network=False)\n",
+        "print(f\"Geodesic distance: {geo_distance:.2f} meters\")\n",
+        "\n",
+        "# Road network distance\n",
+        "road_distance = calculate_distance(coord1, coord2, use_road_network=True)\n",
+        "if road_distance is not None:\n",
+        "    print(f\"Road network distance: {road_distance:.2f} meters\")\n",
+        "else:\n",
+        "    print(\"No road network path found between the points.\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "DnLm-FJqwFux"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
geopy for Geodesic Distance:

Uses the great-circle distance formula to calculate straight-line distance in meters. osmnx for Road Network Distance:

Downloads a road network around the first coordinate. Finds the nearest nodes to both GPS points.
Computes the shortest path distance in meters between these nodes. Flexibility:

The use_road_network parameter lets you choose between geodesic and road-network distances. Handling No Path:

If no road connection exists between the points, the function returns None for road network distance. This function allows you to handle both use cases conveniently.